### PR TITLE
Fixes #32 by forcing strings on rooms/segments

### DIFF
--- a/backend/lib/robots/cecotec/CecotecCongaRobot.js
+++ b/backend/lib/robots/cecotec/CecotecCongaRobot.js
@@ -458,7 +458,7 @@ module.exports = class CecotecCongaRobot extends ValetudoRobot {
                 type: MapLayer.TYPE.SEGMENT,
                 pixels: pixels.flat(),
                 metaData: {
-                    segmentId: room.id.value,
+                    segmentId: room.id.value.toString(),
                     active: room.isEnabled,
                     name: room.name,
                 },


### PR DESCRIPTION
## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
  
# Description

It fixes issue #32 by enforcing the `segmentID` to be a string.
I got the tip/suggestion from Hypfer @ the valetudo telegram group.